### PR TITLE
Refactoring (#19)

### DIFF
--- a/lib/presentation/pages/discovery/collection_point_detail_page.dart
+++ b/lib/presentation/pages/discovery/collection_point_detail_page.dart
@@ -19,6 +19,12 @@ class _CollectionPointDetailPageState extends State<CollectionPointDetailPage> {
   String bulletPoint = "\u2022 ";
   int range = 5;
 
+  @override
+  initState() {
+    super.initState();
+    int subcatLength = widget.collectionPoint.acceptedSubcategories.length;
+    if (subcatLength < range) range = subcatLength;
+  }
 
   List<Widget> _getFormattedOpeningHours() {
     List<String> openingHours = widget.collectionPoint.openingHours.split("|");
@@ -69,7 +75,8 @@ class _CollectionPointDetailPageState extends State<CollectionPointDetailPage> {
                   child: Row(
                     children: [
                       const Icon(Icons.check),
-                      const Padding(padding: EdgeInsets.symmetric(horizontal: 5)),
+                      const Padding(
+                          padding: EdgeInsets.symmetric(horizontal: 5)),
                       Text(Languages.of(context)!.cpWithHazardousMaterial),
                     ],
                   ),
@@ -85,7 +92,8 @@ class _CollectionPointDetailPageState extends State<CollectionPointDetailPage> {
                   child: Row(
                     children: [
                       const Icon(Icons.check),
-                      const Padding(padding: EdgeInsets.symmetric(horizontal: 5)),
+                      const Padding(
+                          padding: EdgeInsets.symmetric(horizontal: 5)),
                       Expanded(
                         child: Text(Languages.of(context)!.cpWithSecondHand),
                       ),
@@ -175,29 +183,40 @@ class _CollectionPointDetailPageState extends State<CollectionPointDetailPage> {
                             style: Theme.of(context).textTheme.headline3,
                           ),
                         ),
-                        ...widget.collectionPoint.acceptedSubcategories.getRange(0, range)
+                        ...widget.collectionPoint.acceptedSubcategories
+                            .getRange(0, range)
                             .map((item) {
                           return Padding(
                               padding: const EdgeInsets.only(bottom: 5),
                               child: Text("$bulletPoint ${item.title}"));
                         }).toList(),
-                        const Padding(padding: EdgeInsets.symmetric(vertical: 5)),
-                        Row(
-                          mainAxisAlignment: MainAxisAlignment.end,
-                          children: [
-                            TextButton(
-                              child: Text(range < widget.collectionPoint.acceptedSubcategories.length
-                                  ? Languages.of(context)!.wasteBinShowMoreLabel
-                                  : Languages.of(context)!.wasteBinShowLessLabel,
+                        const Padding(
+                            padding: EdgeInsets.symmetric(vertical: 5)),
+                        if (widget.collectionPoint.acceptedSubcategories.length != range)
+                          Row(
+                            mainAxisAlignment: MainAxisAlignment.end,
+                            children: [
+                              TextButton(
+                                child: Text(
+                                  range <
+                                          widget.collectionPoint
+                                              .acceptedSubcategories.length
+                                      ? Languages.of(context)!
+                                          .wasteBinShowMoreLabel
+                                      : Languages.of(context)!
+                                          .wasteBinShowLessLabel,
+                                ),
+                                onPressed: () => setState(() {
+                                  range = range ==
+                                          widget.collectionPoint
+                                              .acceptedSubcategories.length
+                                      ? 5
+                                      : widget.collectionPoint
+                                          .acceptedSubcategories.length;
+                                }),
                               ),
-                              onPressed: () => setState(() {
-                                range = range == widget.collectionPoint.acceptedSubcategories.length
-                                    ? 5
-                                    : widget.collectionPoint.acceptedSubcategories.length;
-                              }),
-                            ),
-                          ],
-                        ),
+                            ],
+                          ),
                       ],
                     ),
                   ),


### PR DESCRIPTION
* change color of cross in search history to red for more clarity

* changed dataholder to dataservice and used provider

* divided queries and mutations into separate files

* updated item queries

* updated bookmark queries

* updated dashboard queries

* updated general queries

* updated neighborhood queries

* updated search and tip queries

* updated neighborhood mutations

* updated search mutations

* fixed bookmark mutation errors

* fixed merge errors

* fixed GraphQL from intro

* refactoring

* fixed issue with cp subcategories not shown